### PR TITLE
Fix args bug

### DIFF
--- a/GSP_API/api_controller.py
+++ b/GSP_API/api_controller.py
@@ -544,6 +544,6 @@ def get_reach_id_from_latlon_handler(request):
     """
     Controller that returns the reach_id nearest to valid lat/lon coordinates
     """
-    lat = request.get('lat', '')
-    lon = request.get('lon', '')
+    lat = request.args.get('lat', '')
+    lon = request.args.get('lon', '')
     return jsonify(get_reach_from_latlon(lat, lon))


### PR DESCRIPTION
Sorry, i've been sloppy in keeping track of my commits. i deployed the changes to tethys2 and noticed i didn't have this fix in the container when i couldn't get any results. I had committed it on my computer but never pushed it so it worked locally but not when i ran it on tethys2.

but on the bright side, it works on tethys2 now. for example: https://tethys2.byu.edu/localsptapi/api/GetReachID/?lat=10&lon=10